### PR TITLE
Update TA Emailer.gs

### DIFF
--- a/TA Emailer.gs
+++ b/TA Emailer.gs
@@ -19,7 +19,7 @@ function main() {
 }
 
 function getInfo(body) {
-  body = body.substring(body.indexOf("https://www.torahanytime.com"));  
+  body = body.substring(body.indexOf("https://new.torahanytime.com"));  
   return UrlFetchApp.fetch(`https://www.torahanytime.com/lectures/${body.substring(body.indexOf("lectures?") + 11, body.indexOf("]"))}`).getContentText();
 }
 


### PR DESCRIPTION
TorahAnytime just switched the link in their emails to new.torahanytime.com instead of www.torahanytime.com. I think this fixed the new link issue.